### PR TITLE
WHERE IN statement support

### DIFF
--- a/src/Readdle/Database/FQDBException.php
+++ b/src/Readdle/Database/FQDBException.php
@@ -8,14 +8,15 @@ final class FQDBException extends \RuntimeException
     const PDO_CODE               = 1;
     const FQDB_PROVIDER_CODE     = 2;
 
-    const WRONG_QUERY               = 'Given query does not fit called method';
-    const NO_DB_CONNECTION_ERROR    = 'No DB connection';
-    const NO_ACTIVE_QUERY_ERROR     = 'No active query error';
-    const DB_ALREADY_CONNECTED      = 'Already have active connection to a DB';
-    const NOT_CALLABLE_ERROR        = 'Param is not callable';
-    const CLASS_NOT_EXIST           = 'Class not exists';
-    const PLACEHOLDERS_ERROR        = 'Placeholders not set properly';
-    const IDENTIFIER_QUOTE_ERROR    = 'Could not quote identifier: contains quote character';
+    const WRONG_QUERY                     = 'Given query does not fit called method';
+    const NO_DB_CONNECTION_ERROR          = 'No DB connection';
+    const NO_ACTIVE_QUERY_ERROR           = 'No active query error';
+    const DB_ALREADY_CONNECTED            = 'Already have active connection to a DB';
+    const NOT_CALLABLE_ERROR              = 'Param is not callable';
+    const CLASS_NOT_EXIST                 = 'Class not exists';
+    const PLACEHOLDERS_ERROR              = 'Placeholders not set properly';
+    const IDENTIFIER_QUOTE_ERROR          = 'Could not quote identifier: contains quote character';
+    const WRONG_DATA_TYPE_ON_IN_STATEMENT = 'Data must be array if you use FQDB::PARAM_IN_STATEMENT_VALUES param type';
 
 
 

--- a/tests/FQDBTest.php
+++ b/tests/FQDBTest.php
@@ -371,6 +371,23 @@ class FQDBTest extends PHPUnit_Framework_TestCase {
         $this->assertFalse($this->fqdb->getWarningReporting());
     }
 
+    public function testWhereInStatement() {
+        $this->fqdb->insert("INSERT INTO test (id, content, data) VALUES (1000, 'where_in_test', :data)", [':data' => 'data']);
+        $this->fqdb->insert("INSERT INTO test (id, content, data) VALUES (1001, 'where_in_test', :data)", [':data' => 'data']);
+        $this->fqdb->insert("INSERT INTO test (id, content, data) VALUES (1002, 'where_in_test', :data)", [':data' => 'data']);
+        $this->fqdb->insert("INSERT INTO test (id, content, data) VALUES (1003, 'where_in_test', :data)", [':data' => 'data']);
+        $this->fqdb->insert("INSERT INTO test (id, content, data) VALUES (1004, 'where_in_test', :data)", [':data' => 'data']);
+
+        $result = $this->fqdb->queryTable("SELECT * FROM test WHERE id IN (:idArray)", [
+            ':idArray' => [
+                'data' => [1000,1001,1002,1003,1004],
+                'type' => FQDB::PARAM_FOR_IN_STATEMENT_VALUES
+            ]
+        ]);
+
+        $this->assertEquals(5, count($result));
+    }
+
 
 }
 


### PR DESCRIPTION
added custom param type (FQDB::PARAM_FOR_IN_STATEMENT_VALUES) that describes that passed data array is need to prepare for WHERE IN statement.

now you can use:

```php
$fqdb->queryTable("SELECT * FROM table WHERE id IN (:idArray)", [
  ':idArray' => [
    'data' => [1,2,3],
    'type' => FQDB::PARAM_FOR_IN_STATEMENT_VALUES
  ]
]);
```

fqdb will replace ":idArray" placeholder and convert query to:

```sql
SELECT * FROM table WHERE id IN (:where_in_statement_1_1, :where_in_statement_1_2, :where_in_statement_1_3)
```

with options:

```php
[
  ':where_in_statement_1_1' => 1,
  ':where_in_statement_1_2' => 2,
  ':where_in_statement_1_3' => 3
]
```