### PR TITLE
trim on validating query

### DIFF
--- a/src/Readdle/Database/FQDBExecutor.php
+++ b/src/Readdle/Database/FQDBExecutor.php
@@ -351,6 +351,7 @@ class FQDBExecutor
      */
     protected function _testQueryStarts($query, $needle)
     {
+        $query = trim($query, " \t\n\r");
         if (!preg_match("/^$needle.*/i", $query)) {
             $this->_error(FQDBException::WRONG_QUERY, FQDBException::FQDB_CODE);
         }

--- a/tests/FQDBTest.php
+++ b/tests/FQDBTest.php
@@ -414,6 +414,48 @@ class FQDBTest extends PHPUnit_Framework_TestCase {
 
     }
 
+    public function testTrimmedQuery()
+    {
+        $blobData = chr(7).'test'.chr(0);
+
+        $rowId = 10001;
+
+        $this->fqdb->insert("INSERT INTO test (id, content, data) VALUES (:rowId, 'test_trimmed_query', :data)", [
+            ':data' => new \Readdle\Database\SQLValueBlob($blobData),
+            ':rowId' => $rowId
+        ]);
+
+        $blob = $this->fqdb->queryValue("SELECT `data` FROM test WHERE id=:rowId", [
+            ':rowId' => $rowId
+        ]);
+
+        $this->assertEquals($blobData, $blob);
+
+        $blob = $this->fqdb->queryValue(" SELECT `data` FROM test WHERE id=:rowId", [
+            ':rowId' => $rowId
+        ]);
+
+        $this->assertEquals($blobData, $blob);
+
+        $blob = $this->fqdb->queryValue("\tSELECT `data` FROM test WHERE id=:rowId", [
+            ':rowId' => $rowId
+        ]);
+
+        $this->assertEquals($blobData, $blob);
+
+        $blob = $this->fqdb->queryValue("\nSELECT `data` FROM test WHERE id=:rowId", [
+            ':rowId' => $rowId
+        ]);
+
+        $this->assertEquals($blobData, $blob);
+
+        $blob = $this->fqdb->queryValue("\rSELECT `data` FROM test WHERE id=:rowId", [
+            ':rowId' => $rowId
+        ]);
+
+        $this->assertEquals($blobData, $blob);
+    }
+
 }
 
 


### PR DESCRIPTION
@AndrianBdn @draev @melya 

I think, that this will optimise some butt hurt causes with query string validation.
Now we can use query like this:

```php
$this->fqdb->queryValue("
SELECT `data` FROM test WHERE id=:rowId", [
  ':rowId' => $rowId
]);
```

It is very useful in some cases when we want to more elegance code