### PR TITLE
- Fixes for functions that work with collections 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
-  - 5.5
-  - 5.4
+  - 7.0
+  - 5.6
   - hhvm
 install: composer install
 script: ./vendor/bin/phpunit --configuration phpunit.xml --coverage-text

--- a/src/Readdle/Database/FQDBQueryAPI.php
+++ b/src/Readdle/Database/FQDBQueryAPI.php
@@ -32,13 +32,8 @@ class FQDBQueryAPI extends FQDBExecutor {
      * @return array|false
      */
     private function queryArrayOrFalse($query, $options, $fetcher) {
-        $statement = $this->_runQuery($query, $options);
-        $result = call_user_func($fetcher, $statement);
-
-        if (!is_array($result) || count($result) === 0) {
-            $result = false;
-        }
-        return $result;
+        $result = $this->queryArray($query, $options, $fetcher);
+        return 0 === count($result) ? false : $result;
     }
 
     /**
@@ -52,11 +47,7 @@ class FQDBQueryAPI extends FQDBExecutor {
     {
         $statement = $this->_runQuery($query, $options);
         $result = call_user_func($fetcher, $statement);
-
-        if (!is_array($result) || count($result) === 0) {
-            $result = [];
-        }
-        return $result;
+        return is_array($result) ? $result : [];
     }
 
 

--- a/src/Readdle/Database/FQDBQueryAPI.php
+++ b/src/Readdle/Database/FQDBQueryAPI.php
@@ -33,23 +33,39 @@ class FQDBQueryAPI extends FQDBExecutor {
      */
     private function queryArrayOrFalse($query, $options, $fetcher) {
         $statement = $this->_runQuery($query, $options);
-
         $result = call_user_func($fetcher, $statement);
 
-        if (!is_array($result) || count($result) == 0) {
-            return false;
+        if (!is_array($result) || count($result) === 0) {
+            $result = false;
         }
-        else {
-            return $result;
-        }
+        return $result;
     }
+
+    /**
+     * executes SELECT or SHOW query and returns result array
+     * @param string $query
+     * @param array $options
+     * @param callable $fetcher
+     * @return array
+     */
+    private function queryArray($query, $options, $fetcher)
+    {
+        $statement = $this->_runQuery($query, $options);
+        $result = call_user_func($fetcher, $statement);
+
+        if (!is_array($result) || count($result) === 0) {
+            $result = [];
+        }
+        return $result;
+    }
+
 
     /**
      * executes SELECT or SHOW query and returns first result
      * @param string $query
      * @param array $options
      * @param callable $fetcher
-     * @return mixed|false
+     * @return array|false
      */
     private function queryOrFalse($query, $options, $fetcher)
     {
@@ -67,7 +83,7 @@ class FQDBQueryAPI extends FQDBExecutor {
      * executes SELECT or SHOW query and returns 1st returned element
      * @param string $query
      * @param array $options
-     * @return mixed
+     * @return false|string
      */
     public function queryValue($query, $options = array())
     {
@@ -105,11 +121,11 @@ class FQDBQueryAPI extends FQDBExecutor {
      * executes SELECT or SHOW query and returns result as array
      * @param string $query
      * @param array $options
-     * @return array|false
+     * @return array
      */
     public function queryVector($query, $options = array())
     {
-        return $this->queryArrayOrFalse($query, $options,
+        return $this->queryArray($query, $options,
             function(\PDOStatement $statement) { return $statement->fetchAll(\PDO::FETCH_COLUMN, 0); });
 
     }
@@ -118,11 +134,11 @@ class FQDBQueryAPI extends FQDBExecutor {
      * executes SELECT or SHOW query and returns result as assoc array
      * @param string $query
      * @param array $options
-     * @return array|false
+     * @return array
      */
     public function queryTable($query, $options = array())
     {
-        return $this->queryArrayOrFalse($query, $options,
+        return $this->queryArray($query, $options,
             function(\PDOStatement $statement) { return $statement->fetchAll(\PDO::FETCH_ASSOC); }
         );
     }
@@ -133,7 +149,7 @@ class FQDBQueryAPI extends FQDBExecutor {
      * @param string $className
      * @param array $options
      * @param array $classConstructorArguments
-     * @return array|false
+     * @return array
      */
     public function queryObjArray($query, $className, $options = array(), $classConstructorArguments = NULL)
     {
@@ -141,7 +157,7 @@ class FQDBQueryAPI extends FQDBExecutor {
             $this->_error(FQDBException::CLASS_NOT_EXIST, FQDBException::FQDB_CODE);
         }
 
-        return $this->queryArrayOrFalse($query, $options,
+        return $this->queryArray($query, $options,
             function(\PDOStatement $statement) use ($className, $classConstructorArguments) {
                 return $statement->fetchAll(\PDO::FETCH_CLASS | \PDO::FETCH_PROPS_LATE,
                     $className, $classConstructorArguments);

--- a/src/Readdle/Database/FQDBQueryAPI.php
+++ b/src/Readdle/Database/FQDBQueryAPI.php
@@ -29,18 +29,6 @@ class FQDBQueryAPI extends FQDBExecutor {
      * @param string $query
      * @param array $options
      * @param callable $fetcher
-     * @return array|false
-     */
-    private function queryArrayOrFalse($query, $options, $fetcher) {
-        $result = $this->queryArray($query, $options, $fetcher);
-        return 0 === count($result) ? false : $result;
-    }
-
-    /**
-     * executes SELECT or SHOW query and returns result array
-     * @param string $query
-     * @param array $options
-     * @param callable $fetcher
      * @return array
      */
     private function queryArray($query, $options, $fetcher)
@@ -50,26 +38,6 @@ class FQDBQueryAPI extends FQDBExecutor {
         return is_array($result) ? $result : [];
     }
 
-
-    /**
-     * executes SELECT or SHOW query and returns first result
-     * @param string $query
-     * @param array $options
-     * @param callable $fetcher
-     * @return string|false
-     */
-    private function queryOrFalse($query, $options, $fetcher)
-    {
-        $result = $this->queryArrayOrFalse($query, $options, $fetcher);
-
-        if (false === $result) {
-            return false;
-        }
-
-        return reset($result);
-    }
-
-
     /**
      * executes SELECT or SHOW query and returns 1st returned element
      * @param string $query
@@ -78,8 +46,8 @@ class FQDBQueryAPI extends FQDBExecutor {
      */
     public function queryValue($query, $options = array())
     {
-        return $this->queryOrFalse($query, $options,
-            function(\PDOStatement $statement) { return $statement->fetch(\PDO::FETCH_NUM); });
+        $statement = $this->_runQuery($query, $options);
+        return $statement->fetch(\PDO::FETCH_COLUMN);
     }
 
     /**

--- a/src/Readdle/Database/FQDBQueryAPI.php
+++ b/src/Readdle/Database/FQDBQueryAPI.php
@@ -56,7 +56,7 @@ class FQDBQueryAPI extends FQDBExecutor {
      * @param string $query
      * @param array $options
      * @param callable $fetcher
-     * @return array|false
+     * @return string|false
      */
     private function queryOrFalse($query, $options, $fetcher)
     {
@@ -74,7 +74,7 @@ class FQDBQueryAPI extends FQDBExecutor {
      * executes SELECT or SHOW query and returns 1st returned element
      * @param string $query
      * @param array $options
-     * @return false|string
+     * @return string|false
      */
     public function queryValue($query, $options = array())
     {

--- a/tests/FQDBTest.php
+++ b/tests/FQDBTest.php
@@ -75,7 +75,7 @@ class FQDBTest extends PHPUnit_Framework_TestCase {
 
     public function testQueryVector() {
         $noValues = $this->fqdb->queryVector("SELECT * FROM test WHERE id=100");
-        $this->assertFalse($noValues);
+        $this->assertCount(0, $noValues);
 
         $count = intval($this->fqdb->queryValue("SELECT COUNT(*) FROM test"));
         $values = $this->fqdb->queryVector("SELECT * FROM test");
@@ -85,7 +85,7 @@ class FQDBTest extends PHPUnit_Framework_TestCase {
 
     public function testQueryTable() {
         $noValues = $this->fqdb->queryTable("SELECT * FROM test WHERE id=100");
-        $this->assertFalse($noValues);
+        $this->assertCount(0, $noValues);
 
         $count = intval($this->fqdb->queryValue("SELECT COUNT(*) FROM test"));
         $values = $this->fqdb->queryTable("SELECT * FROM test");
@@ -103,8 +103,20 @@ class FQDBTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testQueryTableCallbackOk() {
-        $noValues = $this->fqdb->queryTableCallback("SELECT * FROM test WHERE id=:id", [':id' => 1], function($row) {return $row;});
-        $this->assertTrue($noValues);
+        $sql = "SELECT * FROM test";
+        $sqlOptions = [];
+
+        $callbackResultArray = [];
+        $resultTrue = $this->fqdb->queryTableCallback($sql, $sqlOptions,
+            function($row) use (&$callbackResultArray) {
+                $callbackResultArray[]=$row;
+                return $row;
+            }
+        );
+        $this->assertTrue($resultTrue);
+
+        $resultArray = $this->fqdb->queryTable($sql, $sqlOptions);
+        $this->assertEquals($resultArray, $callbackResultArray);
     }
 
     /**
@@ -126,7 +138,7 @@ class FQDBTest extends PHPUnit_Framework_TestCase {
 
     public function testQueryObjArray() {
         $noValues = $this->fqdb->queryObjArray("SELECT * FROM test WHERE id=100", '\QueryObject');
-        $this->assertFalse($noValues);
+        $this->assertCount(0, $noValues);
 
         $count = intval($this->fqdb->queryValue("SELECT COUNT(*) FROM test"));
         $objects = $this->fqdb->queryObjArray("SELECT * FROM test", '\QueryObject');
@@ -398,7 +410,7 @@ class FQDBTest extends PHPUnit_Framework_TestCase {
             [':idArray' =>  new \Readdle\Database\SQLArgs(null)]
         );
 
-        $this->assertEquals(1, count($result));
+        $this->assertEquals(0, count($result));
     }
 
     public function testBlobInsert() {

--- a/tests/FQDBTest.php
+++ b/tests/FQDBTest.php
@@ -52,6 +52,9 @@ class FQDBTest extends PHPUnit_Framework_TestCase {
 
         $value = $this->fqdb->queryValue("SELECT * FROM test WHERE id=1");
         $this->assertEquals('1', $value);
+
+        $value = $this->fqdb->queryValue("SELECT data, content FROM test WHERE id=1");
+        $this->assertEquals('data', $value);
     }
 
     public function testQueryList() {

--- a/tests/FQDBTest.php
+++ b/tests/FQDBTest.php
@@ -49,6 +49,9 @@ class FQDBTest extends PHPUnit_Framework_TestCase {
 
         $value = $this->fqdb->queryValue("SELECT id FROM test WHERE id=1");
         $this->assertEquals('1', $value);
+
+        $value = $this->fqdb->queryValue("SELECT * FROM test WHERE id=1");
+        $this->assertEquals('1', $value);
     }
 
     public function testQueryList() {


### PR DESCRIPTION
Fixed return types of functions that work with collections (queryTable, queryVector, queryObjArray)
@readdle/php-team 