### PR TITLE
Weaken symfony/event-dispatcher dependecy in favor of symfony/event-dispatcher-contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v4.1.0
+
+- weakened dependency "symfony/event-dispatcher" in favor of "symfony/event-dispatcher-contracts".
+
+**POTENTIAL BC**: If you're using "symfony/event-dispatcher" as a dispatcher, please install it manually `composer require symfony/event-dispatcher` 
+
 # v4.0.4
 
 - no behavior change, except better compatibility with PHP 8.1

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,22 @@
 {
     "name" : "readdle/fqdb",
-    "version": "4.0.4",
+    "version": "4.1.0",
     "license": "MIT",
     "require" : {
         "php" : ">=7.4",
         "ext-PDO": "*",
         "ext-json": "*",
-        "symfony/event-dispatcher": "^4.3|5.*"
+        "symfony/event-dispatcher-contracts": "^2.0|^3.0"
     },
     "require-dev": {
         "escapestudios/symfony2-coding-standard": "^3.12",
+        "jangregor/phpstan-prophecy": "^1.0",
         "pheromone/phpcs-security-audit": "^2.0",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpstan/phpstan": "^1.2",
-        "phpunit/phpunit": "^9.5",
         "phpspec/prophecy-phpunit": "^2.0",
+        "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan-phpunit": "^1.0",
+        "phpunit/phpunit": "^9.5",
         "slevomat/coding-standard": "^7.0",
         "squizlabs/php_codesniffer": "^3.6"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,8 @@
 includes:
 	- phpstan-baseline.neon
+	- vendor/jangregor/phpstan-prophecy/extension.neon
+	- vendor/phpstan/phpstan-phpunit/extension.neon
+	- vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
 	level: 7

--- a/src/Readdle/Database/FQDBExecutor.php
+++ b/src/Readdle/Database/FQDBExecutor.php
@@ -7,7 +7,7 @@ use Readdle\Database\Connector\Resolver;
 use Readdle\Database\Event\TransactionStarted;
 use Readdle\Database\Event\TransactionCommitted;
 use Readdle\Database\Event\TransactionRolledBack;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class FQDBExecutor implements FQDBInterface

--- a/src/Readdle/Database/FQDBTest.php
+++ b/src/Readdle/Database/FQDBTest.php
@@ -7,25 +7,20 @@ namespace Readdle\Database;
 
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Readdle\Database\Event\DeleteQueryStarted;
 use Readdle\Database\Event\TransactionCommitted;
 use Readdle\Database\Event\TransactionRolledBack;
 use Readdle\Database\Event\TransactionStarted;
 use Readdle\Database\Event\UpdateQueryStarted;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class FQDBTest extends \PHPUnit\Framework\TestCase
 {
     use ProphecyTrait;
     
-    /**
-     * @var FQDB $fqdb
-     */
-    private $fqdb;
-    /**
-     * @var \Prophecy\Prophecy\ObjectProphecy
-     */
-    private $dispatcher;
+    private FQDB $fqdb;
+    /** @var \Prophecy\Prophecy\ObjectProphecy|EventDispatcherInterface */
+    private \Prophecy\Prophecy\ObjectProphecy $dispatcher;
     
     protected function setUp(): void
     {


### PR DESCRIPTION
Suggest to weaken "symfony/event-dispatcher" in favor of "symfony/event-dispatcher-contracts" to avoid issues with upgrading "symfony/event-dispatcher" and allow to support another/own event-dispatchers