### PR TITLE
PHP8.1: Fixed compatibility issues with implementation of \JsonSerializable interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.2.0
+
+- PHP8.1: fixed compatibility issues with \JsonSerializable interface 
+
 # v4.1.0
 
 - weakened dependency "symfony/event-dispatcher" in favor of "symfony/event-dispatcher-contracts".

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name" : "readdle/fqdb",
-    "version": "4.1.0",
+    "version": "4.2.0",
     "license": "MIT",
     "require" : {
         "php" : ">=7.4",
@@ -14,10 +14,10 @@
         "pheromone/phpcs-security-audit": "^2.0",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "slevomat/coding-standard": "^7.0",
+        "slevomat/coding-standard": "^8.4",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {
@@ -27,7 +27,10 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "scripts": {
         "register-standards": "phpcs --config-set installed_paths $(pwd),$(pwd)/vendor/slevomat/coding-standard,$(pwd)/vendor/phpcompatibility/php-compatibility,$(pwd)/vendor/pheromone/phpcs-security-audit,$(pwd)/vendor/escapestudios/symfony2-coding-standard 2>/dev/null || true",

--- a/src/Readdle/Database/SQLArgs.php
+++ b/src/Readdle/Database/SQLArgs.php
@@ -24,7 +24,8 @@ class SQLArgs implements \JsonSerializable
     {
         return $this->argsArray;
     }
-    
+
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->argsArray;

--- a/src/Readdle/Database/SQLArgsArray.php
+++ b/src/Readdle/Database/SQLArgsArray.php
@@ -23,7 +23,8 @@ class SQLArgsArray implements \JsonSerializable
     {
         return $this->argsArray;
     }
-    
+
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->argsArray;

--- a/src/Readdle/Database/SQLValueBlob.php
+++ b/src/Readdle/Database/SQLValueBlob.php
@@ -20,7 +20,8 @@ class SQLValueBlob extends BaseSQLValue
     {
         $statement->bindParam($placeholder, $this->blob, \PDO::PARAM_LOB);
     }
-    
+
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return \base64_encode($this->blob);

--- a/src/Readdle/Database/SQLValueNull.php
+++ b/src/Readdle/Database/SQLValueNull.php
@@ -9,6 +9,7 @@ class SQLValueNull extends BaseSQLValue
         $statement->bindValue($placeholder, null, \PDO::PARAM_NULL);
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return null;


### PR DESCRIPTION
- fixed compatibility issue
- updated phpstan + it's dependencies 

Before with php81:

```
> phpstan analyze -c phpstan.neon
 29/29 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Readdle/Database/SQLArgsArray.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  27     Return type mixed of method Readdle\Database\SQLArgsArray::jsonSerialize() is not covariant with tentative return type mixed of method JsonSerializable::jsonSerialize().
         💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Readdle/Database/SQLValueBlob.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  24     Return type mixed of method Readdle\Database\SQLValueBlob::jsonSerialize() is not covariant with tentative return type mixed of method JsonSerializable::jsonSerialize().
         💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Readdle/Database/SQLValueNull.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  12     Return type mixed of method Readdle\Database\SQLValueNull::jsonSerialize() is not covariant with tentative return type mixed of method JsonSerializable::jsonSerialize().
         💡 Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```